### PR TITLE
Support for listening on localhost with http

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -9,6 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	useHTTP  bool
+	httpPort int
+)
+
 // mcpCommand represents the run command which starts the MCP server
 var mcpCommand = &cobra.Command{
 	Use:     "mcp",
@@ -65,6 +70,9 @@ available to AI applications via the MCP protocol.
 			DescriptionOverride: descriptionOverride,
 		})
 
+		if useHTTP {
+			return srv.StartHTTP(httpPort)
+		}
 		return srv.Start()
 	},
 }
@@ -77,6 +85,10 @@ func init() {
 	mcpCommand.Flags().StringSliceVarP(&description, "description", "d", []string{}, "MCP server description (optional, can be specified multiple times)")
 	mcpCommand.Flags().StringSliceVarP(&descriptionFile, "description-file", "", []string{}, "Read the MCP server description from files (optional, can be specified multiple times)")
 	mcpCommand.Flags().BoolVarP(&descriptionOverride, "description-override", "", false, "Override the description found in the config file")
+
+	// Add HTTP server flags
+	mcpCommand.Flags().BoolVar(&useHTTP, "http", false, "Enable HTTP server mode")
+	mcpCommand.Flags().IntVar(&httpPort, "port", 8080, "Port for HTTP server")
 
 	// Mark required flags
 	_ = mcpCommand.MarkFlagRequired("config")

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -87,8 +87,8 @@ func init() {
 	mcpCommand.Flags().BoolVarP(&descriptionOverride, "description-override", "", false, "Override the description found in the config file")
 
 	// Add HTTP server flags
-	mcpCommand.Flags().BoolVar(&useHTTP, "http", false, "Enable HTTP server mode")
-	mcpCommand.Flags().IntVar(&httpPort, "port", 8080, "Port for HTTP server")
+	mcpCommand.Flags().BoolVar(&useHTTP, "http", false, "Enable HTTP server mode (serve MCP over HTTP/SSE instead of stdio)")
+	mcpCommand.Flags().IntVar(&httpPort, "port", 8080, "Port for HTTP server (default: 8080, only used with --http)")
 
 	// Mark required flags
 	_ = mcpCommand.MarkFlagRequired("config")

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,10 +74,15 @@ mcpshell mcp [flags]
 
 Runs an MCP server that communicates using the Model Context Protocol and exposes the tools defined in a MCP configuration file. The server loads tool definitions from a YAML configuration file and makes them available to AI applications via the MCP protocol.
 
+**HTTP/SSE Mode**:
+
+- `--http`: Enable HTTP server mode (serve MCP over HTTP/SSE instead of stdio)
+- `--port`: Port for HTTP server (default: 8080, only used with --http)
+
 **Example**:
 
 ```console
-mcpshell mcp --config=examples/config.yaml --log-level=debug
+mcpshell mcp --config=examples/config.yaml --http --port=9090 --log-level=debug
 ```
 
 ### EXE Command


### PR DESCRIPTION
This change enables mcpshell to listen on localhost on a specified port for http connections.  Mode and port are specified with the --http and --port options when the command mode is "mcp".  This enables integration with amazonq and claude desktop.